### PR TITLE
Allow multiple listeners per callback module

### DIFF
--- a/src/config_listener.erl
+++ b/src/config_listener.erl
@@ -4,6 +4,7 @@
 
 %% Public interface
 -export([start/2]).
+-export([start/3]).
 
 -export([behaviour_info/1]).
 
@@ -17,7 +18,10 @@ behaviour_info(_) ->
     undefined.
 
 start(Module, State) ->
-    gen_event:add_sup_handler(config_event, {?MODULE, Module}, {Module, State}).
+    start(Module, Module, State).
+
+start(Module, Id, State) ->
+    gen_event:add_sup_handler(config_event, {?MODULE, Id}, {Module, State}).
 
 init({Module, State}) ->
     {ok, {Module, State}}.


### PR DESCRIPTION
Useful for couch_rep_httpc.

BugzID: 13179
