### PR TITLE
Increment counter on config change

### DIFF
--- a/priv/stat_descriptions.cfg
+++ b/priv/stat_descriptions.cfg
@@ -6,3 +6,91 @@
     {type, counter},
     {desc, <<"number of times a configuration value has been deleted">>}
 ]}.
+{[config, cloudant, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section cloudant">>}
+]}.
+{[config, cloudant, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section cloudant">>}
+]}.
+{[config, cluster, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section cluster">>}
+]}.
+{[config, cluster, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section cluster">>}
+]}.
+{[config, couchdb, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section couchdb">>}
+]}.
+{[config, couchdb, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section couchdb">>}
+]}.
+{[config, fabric, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section fabric">>}
+]}.
+{[config, fabric, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section fabric">>}
+]}.
+{[config, global_changes, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section global_changes">>}
+]}.
+{[config, global_changes, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section global_changes">>}
+]}.
+{[config, ioq, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section ioq">>}
+]}.
+{[config, ioq, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section ioq">>}
+]}.
+{[config, log, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section log">>}
+]}.
+{[config, log, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section log">>}
+]}.
+{[config, mem3, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section mem3">>}
+]}.
+{[config, mem3, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section mem3">>}
+]}.
+{[config, rexi, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section rexi">>}
+]}.
+{[config, rexi, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section rexi">>}
+]}.
+{[config, smoosh, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section smoosh">>}
+]}.
+{[config, smoosh, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section smoosh">>}
+]}.
+{[config, view_updater, set], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been set in section view_updater">>}
+]}.
+{[config, view_updater, delete], [
+    {type, counter},
+    {desc, <<"number of times a configuration value has been deleted in section view_updater">>}
+]}.

--- a/src/config.erl
+++ b/src/config.erl
@@ -201,6 +201,7 @@ handle_call({set, Sec, Key, Val, Persist, Reason}, _From, Config) ->
         [?MODULE, Sec, Key, Val, Reason]
     ),
     couch_stats:increment_counter([config, set]),
+    couch_stats:increment_counter([config, list_to_atom(Sec), set]),
     case {Persist, Config#config.write_filename} of
         {true, undefined} ->
             ok;
@@ -220,6 +221,7 @@ handle_call({delete, Sec, Key, Persist, Reason}, _From, Config) ->
         [?MODULE, Sec, Key, Reason]
     ),
     couch_stats:increment_counter([config, delete]),
+    couch_stats:increment_counter([config, list_to_atom(Sec), delete]),
     case {Persist, Config#config.write_filename} of
         {true, undefined} ->
             ok;


### PR DESCRIPTION
Increment a counter when a configuration variable is set or
deleted. When collected periodically (via collectd or such like)
and stored in graphite this data can be used to plot the times at
which configuration changes were made on a node. This should
make it easier for operators to relate configuration changes to
other metrics.

BugzID: 29704
